### PR TITLE
Moved tool_recyclebin_pre_course_module_delete() in to an adhoc task

### DIFF
--- a/admin/tool/recyclebin/classes/task/category_bin_item.php
+++ b/admin/tool/recyclebin/classes/task/category_bin_item.php
@@ -1,0 +1,53 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Recycle bin backup cron task.
+ *
+ * @package    tool_recyclebin
+ * @copyright  AVADO 2018
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace tool_recyclebin\task;
+
+use tool_recyclebin\course_bin;
+
+class category_bin_item extends \core\task\adhoc_task {
+
+    /**
+     * Task name.
+     */
+    public function get_name() {
+        return get_string('categorybinitem', 'tool_recyclebin');
+    }
+
+    /**
+     * Add deleted item to recyclebin.
+     * @param $cm \stdClass $cm The course module record.
+     * @return bool
+     */
+    public function execute() {
+        $cm = self::get_custom_data();
+        $coursebin = new course_bin($cm->course);
+        try {
+            $coursebin->store_item($cm);
+        } catch (\moodle_exception $e) {
+            // Something went wrong.
+        }
+        return true;
+    }
+}

--- a/admin/tool/recyclebin/lang/en/tool_recyclebin.php
+++ b/admin/tool/recyclebin/lang/en/tool_recyclebin.php
@@ -56,3 +56,4 @@ $string['recyclebin:deleteitems'] = 'Delete recycle bin items';
 $string['recyclebin:restoreitems'] = 'Restore recycle bin items';
 $string['recyclebin:viewitems'] = 'View recycle bin items';
 $string['privacy:metadata'] = 'The Recycle bin plugin does not store any personal data.';
+$string['recyclebin:categorybinitem'] = 'Add recyclebin item';

--- a/admin/tool/recyclebin/lib.php
+++ b/admin/tool/recyclebin/lib.php
@@ -147,8 +147,9 @@ function tool_recyclebin_extend_navigation_category_settings($navigation, $conte
  */
 function tool_recyclebin_pre_course_module_delete($cm) {
     if (\tool_recyclebin\course_bin::is_enabled()) {
-        $coursebin = new \tool_recyclebin\course_bin($cm->course);
-        $coursebin->store_item($cm);
+        $recyclebin = new \tool_recyclebin\task\category_bin_item();
+        $recyclebin->set_custom_data($cm);
+        \core\task\manager::queue_adhoc_task($recyclebin);
     }
 }
 


### PR DESCRIPTION
I have moved the logic that was initially inside _tool_recyclebin_pre_course_module_delete()_ to an adhoc task within _admin/tool/recyclebin_. The logic is otherwise the same.
